### PR TITLE
Refactor and Fix Ubuntu Test

### DIFF
--- a/tests/unit/linux/test_Ubuntu.py
+++ b/tests/unit/linux/test_Ubuntu.py
@@ -10,10 +10,10 @@ from k8_vmware.vsphere.VM_Create import VM_Create
 class test_Ubuntu(TestCase):
 
     def setUp(self) -> None:
-        self.vm_create = VM_Create()
-        self.vm = self.vm_create.create()
-        self.vm_name = self.vm_create.vm_name
-        self.ubuntu = Ubuntu(self.vm_name)
+        self.vm_create  = VM_Create()
+        self.vm         = self.vm_create.create()
+        self.vm_name    = self.vm_create.vm_name
+        self.ubuntu     = Ubuntu(self.vm_name)
 
     def tearDown(self) -> None:
         self.vm.task().delete()
@@ -22,18 +22,17 @@ class test_Ubuntu(TestCase):
         assert self.ubuntu.vm_name == self.vm_name
 
     def test_vm(self):
-        with View_Soap_Calls():
-            assert self.ubuntu.vm().name() == self.vm_name
+        assert self.ubuntu.vm().name() == self.vm_name
+        assert self.ubuntu.exists()
 
-    def test_query(self):
+    def test_sample_properties_fetch(self):
         sdk = self.ubuntu.sdk
         vm = sdk.get_object(pyVmomi.vim.VirtualMachine, self.vm_name)
         assert vm.name == self.vm_name
 
         properties = ['parent', 'configStatus', 'config', 'tag']
-        with View_Soap_Calls(show_calls=True, show_xml=False):
-            result = sdk.get_objects_properties(pyVmomi.vim.VirtualMachine, [vm], properties)
-            self.assertIsNotNone(result.get(self.vm.id()).get("config"))
-            self.assertIsNotNone(result.get(self.vm.id()).get("parent"))
-            self.assertIsNotNone(result.get(self.vm.id()).get("configStatus"))
-            self.assertIsNotNone(result.get(self.vm.id()).get("tag"))
+        result = sdk.get_objects_properties(pyVmomi.vim.VirtualMachine, [vm], properties)
+        self.assertIsNotNone(result.get(self.vm.id()).get("config"))
+        self.assertIsNotNone(result.get(self.vm.id()).get("parent"))
+        self.assertIsNotNone(result.get(self.vm.id()).get("configStatus"))
+        self.assertIsNotNone(result.get(self.vm.id()).get("tag"))

--- a/tests/unit/linux/test_Ubuntu.py
+++ b/tests/unit/linux/test_Ubuntu.py
@@ -2,7 +2,6 @@ from unittest import TestCase
 
 import pyVmomi
 
-from k8_vmware.helpers.View_Soap_Calls import View_Soap_Calls
 from k8_vmware.linux.Ubuntu import Ubuntu
 from k8_vmware.vsphere.VM_Create import VM_Create
 

--- a/tests/unit/linux/test_Ubuntu.py
+++ b/tests/unit/linux/test_Ubuntu.py
@@ -1,20 +1,22 @@
-from pprint import pprint
 from unittest import TestCase
 
 import pyVmomi
-from pytest import skip
 
 from k8_vmware.helpers.View_Soap_Calls import View_Soap_Calls
 from k8_vmware.linux.Ubuntu import Ubuntu
+from k8_vmware.vsphere.VM_Create import VM_Create
 
 
 class test_Ubuntu(TestCase):
 
     def setUp(self) -> None:
-        self.vm_name = "file-drop"              # todo: once we have the ability to create new VMs programatically use temp ones here
-        self.ubuntu  = Ubuntu(self.vm_name)
-        if self.ubuntu.vm() is None:
-            skip("VM didn't exist in server")
+        self.vm_create = VM_Create()
+        self.vm = self.vm_create.create()
+        self.vm_name = self.vm_create.vm_name
+        self.ubuntu = Ubuntu(self.vm_name)
+
+    def tearDown(self) -> None:
+        self.vm.task().delete()
 
     def test__init__(self):
         assert self.ubuntu.vm_name == self.vm_name
@@ -23,59 +25,15 @@ class test_Ubuntu(TestCase):
         with View_Soap_Calls():
             assert self.ubuntu.vm().name() == self.vm_name
 
-    # todo: refactor into VM code
-    def create_filter_spec(self, pc, vms, prop):
-        objSpecs = []
-        for vm in vms:
-            objSpec = pyVmomi.vmodl.query.PropertyCollector.ObjectSpec(obj=vm)
-            objSpecs.append(objSpec)
-        filterSpec = pyVmomi.vmodl.query.PropertyCollector.FilterSpec()
-        filterSpec.objectSet = objSpecs
-        propSet = pyVmomi.vmodl.query.PropertyCollector.PropertySpec(all=False)
-        propSet.type = pyVmomi.vim.VirtualMachine
-        if prop:
-            propSet.pathSet = [prop]
-        else:
-            propSet.pathSet = []
-        filterSpec.propSet = [propSet]
-        return filterSpec
-
     def test_query(self):
         sdk = self.ubuntu.sdk
-        vm_name = 'fire-drop'
-        args = vm_name
-        result = sdk.get_object(pyVmomi.vim.VirtualMachine, args)
-        pprint(result)
+        vm = sdk.get_object(pyVmomi.vim.VirtualMachine, self.vm_name)
+        assert vm.name == self.vm_name
 
-        args = "alarm"
-        args = "parent"
-        args = "config"
-        args = "configStatus"
-        #args = "tag"
+        properties = ['parent', 'configStatus', 'config', 'tag']
         with View_Soap_Calls(show_calls=True, show_xml=False):
-            vms = sdk.get_objects_Virtual_Machines()
-
-            pc = sdk.service_instance().content.propertyCollector
-            filter_spec = self.create_filter_spec(pc, vms, args)
-            options = pyVmomi.vmodl.query.PropertyCollector.RetrieveOptions()
-            result = pc.RetrievePropertiesEx([filter_spec], options)
-            #pprint(result)
-            #vms = filter_results(result, args.value)
-            #print("VMs with %s = %s" % (args.property, args.value))
-            #for vm in vms:
-            #    print(vm.name)
-
-
-        return
-
-
-
-
-        print()
-
-        print(self.ubuntu.sdk.vm('fire-drop'))
-
-        print(self.ubuntu.sdk.get_object_virtual_machine(self.vm_name))
-        print(self.ubuntu.vm())
-
-        pprint(self.ubuntu.sdk.vms_names())
+            result = sdk.get_objects_properties(pyVmomi.vim.VirtualMachine, [vm], properties)
+            self.assertIsNotNone(result.get(self.vm.id()).get("config"))
+            self.assertIsNotNone(result.get(self.vm.id()).get("parent"))
+            self.assertIsNotNone(result.get(self.vm.id()).get("configStatus"))
+            self.assertIsNotNone(result.get(self.vm.id()).get("tag"))


### PR DESCRIPTION
- Modify test_Ubuntu to dynamically create VMs
- Cleanup code to use SDK API

New Test Execution Time:
3.00s call     tests/unit/linux/test_Ubuntu.py::test_Ubuntu::test_sample_properties_fetch
2.81s call     tests/unit/linux/test_Ubuntu.py::test_Ubuntu::test_vm
 2.16s call     tests/unit/linux/test_Ubuntu.py::test_Ubuntu::test__init__

Coverage:
k8_vmware/linux/Ubuntu.py                          12      0   100%
k8_vmware/vsphere/Sdk.py                          192      2    99%